### PR TITLE
Remove nested package imports

### DIFF
--- a/.changeset/sweet-bats-own.md
+++ b/.changeset/sweet-bats-own.md
@@ -4,6 +4,6 @@
 ---
 
 @llm-ui/react/{core,examples,throttle} -> @llm-ui/react
-@llm-ui/code/{shikiBundles/allLangs,shikiBundles/allThemes} -> @llm-ui/code
+@llm-ui/code/shikiBundles/{allLangs,allThemes} -> @llm-ui/code
 
 Removes exports more than one level deep (e.g. @llm-ui/react/core) since they don't work with older moduleResolution settings in TypeScript (which react-script uses by default).

--- a/.changeset/sweet-bats-own.md
+++ b/.changeset/sweet-bats-own.md
@@ -1,0 +1,9 @@
+---
+"@llm-ui/code": minor
+"@llm-ui/react": minor
+---
+
+@llm-ui/react/{core,examples,throttle} -> @llm-ui/react
+@llm-ui/code/{shikiBundles/allLangs,shikiBundles/allThemes} -> @llm-ui/code
+
+Removes exports more than one level deep (e.g. @llm-ui/react/core) since they don't work with older moduleResolution settings in TypeScript (which react-script uses by default).

--- a/apps/www/src/components/examples/Buttons.tsx
+++ b/apps/www/src/components/examples/Buttons.tsx
@@ -4,7 +4,7 @@ import {
   findPartialButtons,
   parseCompleteButtons,
 } from "@llm-ui/buttons";
-import type { LLMOutputBlock, LLMOutputComponent } from "@llm-ui/react/core";
+import type { LLMOutputBlock, LLMOutputComponent } from "@llm-ui/react";
 import { Button } from "../ui/Button";
 
 type OnClick = (buttonText: string) => void;

--- a/apps/www/src/components/examples/CodeBlock.tsx
+++ b/apps/www/src/components/examples/CodeBlock.tsx
@@ -5,10 +5,7 @@ import {
   findPartialCodeBlock,
   parseCompleteMarkdownCodeBlock,
 } from "@llm-ui/code";
-import {
-  type LLMOutputBlock,
-  type LLMOutputComponent,
-} from "@llm-ui/react/core";
+import { type LLMOutputBlock, type LLMOutputComponent } from "@llm-ui/react";
 import { CodeBlock } from "../ui/custom/CodeBlock";
 
 const ShikiBlockComponent: LLMOutputComponent = ({ blockMatch }) => {

--- a/apps/www/src/components/examples/Example.tsx
+++ b/apps/www/src/components/examples/Example.tsx
@@ -3,18 +3,16 @@ import { multipleStars } from "@/animations/stars";
 import { cn, delay } from "@/lib/utils";
 import { markdownLookBack } from "@llm-ui/markdown";
 import {
+  stringToTokenArray,
   useLLMOutput,
+  useStreamTokenArray,
   type BlockMatch,
   type LLMOutputBlock,
-  type UseLLMOutputReturn,
-} from "@llm-ui/react/core";
-import {
-  stringToTokenArray,
-  useStreamTokenArray,
   type TokenWithDelay,
+  type UseLLMOutputReturn,
   type UseStreamTokenArrayOptions,
   type UseStreamWithProbabilitiesOptions,
-} from "@llm-ui/react/examples";
+} from "@llm-ui/react";
 import React, {
   Fragment,
   useCallback,

--- a/apps/www/src/components/examples/ExampleMdx.tsx
+++ b/apps/www/src/components/examples/ExampleMdx.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import type { UseStreamWithProbabilitiesOptions } from "@llm-ui/react/examples";
+import type { UseStreamWithProbabilitiesOptions } from "@llm-ui/react";
 import {
   ExampleSideBySide as ExampleSideBySideOriginal,
   ExampleTabs as ExampleTabsOriginal,

--- a/apps/www/src/components/examples/Markdown.tsx
+++ b/apps/www/src/components/examples/Markdown.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { type LLMOutputComponent } from "@llm-ui/react/core";
+import { type LLMOutputComponent } from "@llm-ui/react";
 import ReactMarkdown, { type Options } from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/apps/www/src/components/examples/contants.ts
+++ b/apps/www/src/components/examples/contants.ts
@@ -1,4 +1,4 @@
-import type { ProbabilityOptions } from "@llm-ui/react/examples";
+import type { ProbabilityOptions } from "@llm-ui/react";
 
 export const defaultExampleProbs: ProbabilityOptions = {
   delayMsProbabilities: [{ delayMs: 90, prob: 1 }],

--- a/apps/www/src/components/examples/examples.ts
+++ b/apps/www/src/components/examples/examples.ts
@@ -1,8 +1,5 @@
 import { HIDDEN_CHAR } from "@/constants/constants";
-import {
-  stringToTokenArray,
-  type TokenWithDelay,
-} from "@llm-ui/react/examples";
+import { stringToTokenArray, type TokenWithDelay } from "@llm-ui/react";
 import { defaultExampleProbs } from "./contants";
 
 const ctaBeforePause = `# llm-ui

--- a/apps/www/src/components/examples/throttle.ts
+++ b/apps/www/src/components/examples/throttle.ts
@@ -1,4 +1,4 @@
-import { throttleBasic } from "@llm-ui/react/throttle";
+import { throttleBasic } from "@llm-ui/react";
 
 export type ThrottleType = "buffered" | "low-lag";
 

--- a/apps/www/src/components/shikiConfig.ts
+++ b/apps/www/src/components/shikiConfig.ts
@@ -1,6 +1,5 @@
 import type { ShikiProps } from "@llm-ui/code";
-import { loadHighlighter } from "@llm-ui/code";
-import { allLangs, allLangsAlias } from "@llm-ui/code/shikiBundles/allLangs";
+import { allLangs, allLangsAlias, loadHighlighter } from "@llm-ui/code";
 import { getHighlighterCore } from "shiki/core";
 import githubDark from "shiki/themes/github-dark.mjs";
 import githubLight from "shiki/themes/github-light.mjs";

--- a/apps/www/src/content/docs/advanced/example-hooks.mdx
+++ b/apps/www/src/content/docs/advanced/example-hooks.mdx
@@ -10,7 +10,7 @@ Example:
 <CodeBlockInline>
 
 ```ts
-import { useStreamExample } from "@llm-ui/react/examples";
+import { useStreamExample } from "@llm-ui/react";
 
 const Example = () => {
   const example = "# Hello llm-ui!";

--- a/apps/www/src/content/docs/advanced/throttle-functions.mdx
+++ b/apps/www/src/content/docs/advanced/throttle-functions.mdx
@@ -36,7 +36,7 @@ llm-ui comes with a built-in throttle function:
 `throttleBasic` is the default throttle function for llm-ui.
 
 ```ts
-import { throttleBasic } from "@llm-ui/react/throttle";
+import { throttleBasic } from "@llm-ui/react";
 
 const throttle = throttleBasic({
   readAheadChars: 10,

--- a/apps/www/src/content/docs/blocks/code.mdx
+++ b/apps/www/src/content/docs/blocks/code.mdx
@@ -158,7 +158,7 @@ Change the import:
 
 ```tsx
 // Before:
-import { allThemes } from "@llm-ui/code/shikiBundles/allThemes";
+import { allThemes } from "@llm-ui/code";
 
 // After:
 import githubDark from "shiki/themes/github-dark.mjs";

--- a/apps/www/src/content/docs/llm-output-hook.mdx
+++ b/apps/www/src/content/docs/llm-output-hook.mdx
@@ -16,7 +16,7 @@ Example:
 <CodeBlockInline>
 
 ```typescript
-import { useLLMOutput } from "@llm-ui/react/core";
+import { useLLMOutput } from "@llm-ui/react";
 
 const { blockMatches } = useLLMOutput({
   llmOutput: "llm output",

--- a/apps/www/src/snippets/markdownBlock.ts
+++ b/apps/www/src/snippets/markdownBlock.ts
@@ -37,9 +37,9 @@ export default Example`.replaceAll("STEP1", step1Replace);
 
 const step2Imports = `import {
   useLLMOutput,
-} from "@llm-ui/react/core";
+} from "@llm-ui/react";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useStreamExample } from "@llm-ui/react/examples";
+import { useStreamExample } from "@llm-ui/react";
 `;
 
 export const markdownStep1 = markdownQuickStart;
@@ -48,12 +48,12 @@ export const markdownStep2 = `${step2Imports}\n\n${getLlmUiOutputUsage("// from 
 
 export const fullImports = `import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { type LLMOutputComponent } from "@llm-ui/react/core";
 import {
   useLLMOutput,
-} from "@llm-ui/react/core";
-import { markdownLookBack } from "@llm-ui/markdown";
-import { useStreamExample } from "@llm-ui/react/examples";`;
+  useStreamExample,
+  type LLMOutputComponent
+} from "@llm-ui/react";
+import { markdownLookBack } from "@llm-ui/markdown";`;
 
 const step1Comment = "// -------Step 1: Create a markdown component-------";
 const step2Comment = "// -------Step 2: Render markdown with llm-ui-------";

--- a/apps/www/src/snippets/quickStart.ts
+++ b/apps/www/src/snippets/quickStart.ts
@@ -1,6 +1,6 @@
 export const markdownImports = `import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { type LLMOutputComponent } from "@llm-ui/react/core";
+import { type LLMOutputComponent } from "@llm-ui/react";
 `;
 
 export const markdownComponent = `// Customize this component with your own styling
@@ -21,7 +21,7 @@ import {
   // see: https://llm-ui.com/docs/blocks/code#bundle-size
   allThemes
 } from "@llm-ui/code";
-import { type LLMOutputComponent } from "@llm-ui/react/core";
+import { type LLMOutputComponent } from "@llm-ui/react";
 import parseHtml from "html-react-parser";
 import { getHighlighterCore } from "shiki/core";
 import getWasm from "shiki/wasm";`;
@@ -65,8 +65,7 @@ export const llmUiOutputImports = `import {
   findPartialCodeBlock,
 } from "@llm-ui/code";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput } from "@llm-ui/react/core";
-import { useStreamExample } from "@llm-ui/react/examples";`;
+import { useLLMOutput, useStreamExample } from "@llm-ui/react";`;
 
 export const introExampleHidden = `## Python
 
@@ -159,8 +158,7 @@ import {
   allThemes,
 } from "@llm-ui/code";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
-import { useStreamExample } from "@llm-ui/react/examples";
+import { useLLMOutput, type LLMOutputComponent, useStreamExample } from "@llm-ui/react";
 import parseHtml from "html-react-parser";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";

--- a/apps/www/src/snippets/quickStart.ts
+++ b/apps/www/src/snippets/quickStart.ts
@@ -12,10 +12,15 @@ const MarkdownComponent: LLMOutputComponent = ({ blockMatch }) => {
 export const markdownQuickStart = `${markdownImports}\n\n${markdownComponent}`;
 
 export const codeblockImports = `import type { CodeToHtmlOptions } from "@llm-ui/code";
-import { loadHighlighter, useCodeBlockToHtml, allLangs, allLangsAlias } from "@llm-ui/code";
-// WARNING: Importing allThemes increases your bundle size
-// see: https://llm-ui.com/docs/blocks/code#bundle-size
-import { allThemes } from "@llm-ui/code/shikiBundles/allThemes";
+import {
+  loadHighlighter,
+  useCodeBlockToHtml,
+  allLangs,
+  allLangsAlias,
+  // WARNING: Importing allThemes increases your bundle size
+  // see: https://llm-ui.com/docs/blocks/code#bundle-size
+  allThemes
+} from "@llm-ui/code";
 import { type LLMOutputComponent } from "@llm-ui/react/core";
 import parseHtml from "html-react-parser";
 import { getHighlighterCore } from "shiki/core";
@@ -148,9 +153,11 @@ import {
   loadHighlighter,
   useCodeBlockToHtml,
   allLangs,
-  allLangsAlias
+  allLangsAlias,
+  // WARNING: Importing allThemes will increase your bundle size
+  // See: https://llm-ui.com/docs/blocks/code#bundle-size
+  allThemes,
 } from "@llm-ui/code";
-import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
 import { useStreamExample } from "@llm-ui/react/examples";

--- a/apps/www/src/snippets/quickStart.ts
+++ b/apps/www/src/snippets/quickStart.ts
@@ -12,8 +12,7 @@ const MarkdownComponent: LLMOutputComponent = ({ blockMatch }) => {
 export const markdownQuickStart = `${markdownImports}\n\n${markdownComponent}`;
 
 export const codeblockImports = `import type { CodeToHtmlOptions } from "@llm-ui/code";
-import { loadHighlighter, useCodeBlockToHtml } from "@llm-ui/code";
-import { allLangs, allLangsAlias } from "@llm-ui/code/shikiBundles/allLangs";
+import { loadHighlighter, useCodeBlockToHtml, allLangs, allLangsAlias } from "@llm-ui/code";
 // WARNING: Importing allThemes increases your bundle size
 // see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { allThemes } from "@llm-ui/code/shikiBundles/allThemes";
@@ -148,8 +147,9 @@ import {
   findPartialCodeBlock,
   loadHighlighter,
   useCodeBlockToHtml,
+  allLangs,
+  allLangsAlias
 } from "@llm-ui/code";
-import { allLangs, allLangsAlias } from "@llm-ui/code/shikiBundles/allLangs";
 import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";

--- a/examples/nextjs/src/app/examples/buttons/page.tsx
+++ b/examples/nextjs/src/app/examples/buttons/page.tsx
@@ -6,8 +6,11 @@ import {
   parseCompleteButtons,
 } from "@llm-ui/buttons";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
-import { useStreamExample } from "@llm-ui/react/examples";
+import {
+  useLLMOutput,
+  useStreamExample,
+  type LLMOutputComponent,
+} from "@llm-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/examples/nextjs/src/app/examples/code-block/example.tsx
+++ b/examples/nextjs/src/app/examples/code-block/example.tsx
@@ -1,13 +1,14 @@
 "use client";
 import type { CodeToHtmlOptions } from "@llm-ui/code";
 import {
+  allLangs,
+  allLangsAlias,
   codeBlockLookBack,
   findCompleteCodeBlock,
   findPartialCodeBlock,
   loadHighlighter,
   useCodeBlockToHtml,
 } from "@llm-ui/code";
-import { allLangs, allLangsAlias } from "@llm-ui/code/shikiBundles/allLangs";
 import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";

--- a/examples/nextjs/src/app/examples/code-block/example.tsx
+++ b/examples/nextjs/src/app/examples/code-block/example.tsx
@@ -3,13 +3,15 @@ import type { CodeToHtmlOptions } from "@llm-ui/code";
 import {
   allLangs,
   allLangsAlias,
+  // WARNING: Importing allThemes will increase your bundle size
+  // see: https://llm-ui.com/docs/blocks/code#bundle-size
+  allThemes,
   codeBlockLookBack,
   findCompleteCodeBlock,
   findPartialCodeBlock,
   loadHighlighter,
   useCodeBlockToHtml,
 } from "@llm-ui/code";
-import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
 import { useStreamExample } from "@llm-ui/react/examples";

--- a/examples/nextjs/src/app/examples/code-block/example.tsx
+++ b/examples/nextjs/src/app/examples/code-block/example.tsx
@@ -13,8 +13,11 @@ import {
   useCodeBlockToHtml,
 } from "@llm-ui/code";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
-import { useStreamExample } from "@llm-ui/react/examples";
+import {
+  useLLMOutput,
+  useStreamExample,
+  type LLMOutputComponent,
+} from "@llm-ui/react";
 import parseHtml from "html-react-parser";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";

--- a/examples/nextjs/src/app/examples/markdown/page.tsx
+++ b/examples/nextjs/src/app/examples/markdown/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
-import { useStreamExample } from "@llm-ui/react/examples";
+import {
+  useLLMOutput,
+  useStreamExample,
+  type LLMOutputComponent,
+} from "@llm-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/examples/nextjs/src/app/examples/openai/example.tsx
+++ b/examples/nextjs/src/app/examples/openai/example.tsx
@@ -4,13 +4,15 @@ import type { CodeToHtmlOptions } from "@llm-ui/code";
 import {
   allLangs,
   allLangsAlias,
+  // WARNING: Importing allThemes will increase your bundle size
+  // see: https://llm-ui.com/docs/blocks/code#bundle-size
+  allThemes,
   codeBlockLookBack,
   findCompleteCodeBlock,
   findPartialCodeBlock,
   loadHighlighter,
   useCodeBlockToHtml,
 } from "@llm-ui/code";
-import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
 import parseHtml from "html-react-parser";

--- a/examples/nextjs/src/app/examples/openai/example.tsx
+++ b/examples/nextjs/src/app/examples/openai/example.tsx
@@ -14,7 +14,7 @@ import {
   useCodeBlockToHtml,
 } from "@llm-ui/code";
 import { markdownLookBack } from "@llm-ui/markdown";
-import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";
+import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react";
 import parseHtml from "html-react-parser";
 import { useCallback, useState } from "react";
 import ReactMarkdown from "react-markdown";

--- a/examples/nextjs/src/app/examples/openai/example.tsx
+++ b/examples/nextjs/src/app/examples/openai/example.tsx
@@ -2,13 +2,14 @@
 import { MARKDOWN_PROMPT, NEWLINE } from "@/constants";
 import type { CodeToHtmlOptions } from "@llm-ui/code";
 import {
+  allLangs,
+  allLangsAlias,
   codeBlockLookBack,
   findCompleteCodeBlock,
   findPartialCodeBlock,
   loadHighlighter,
   useCodeBlockToHtml,
 } from "@llm-ui/code";
-import { allLangs, allLangsAlias } from "@llm-ui/code/shikiBundles/allLangs";
 import { allThemes } from "@llm-ui/code/shikiBundles/allThemes"; // WARNING: This import will increase your bundle size, see: https://llm-ui.com/docs/blocks/code#bundle-size
 import { markdownLookBack } from "@llm-ui/markdown";
 import { useLLMOutput, type LLMOutputComponent } from "@llm-ui/react/core";

--- a/packages/buttons/src/lookBack.test.ts
+++ b/packages/buttons/src/lookBack.test.ts
@@ -1,4 +1,4 @@
-import { LookBack } from "@llm-ui/react/core";
+import { LookBack } from "@llm-ui/react";
 import { describe, expect, it } from "vitest";
 import { buttonsLookBack } from "./lookBack";
 

--- a/packages/buttons/src/lookBack.ts
+++ b/packages/buttons/src/lookBack.ts
@@ -1,4 +1,4 @@
-import { LookBackFunction } from "@llm-ui/react/core";
+import { LookBackFunction } from "@llm-ui/react";
 import { Button, parseCompleteButtons } from "./parse";
 
 const buttonsToVisibleText = (buttons: string[] | undefined): string =>

--- a/packages/buttons/src/matchers.ts
+++ b/packages/buttons/src/matchers.ts
@@ -1,4 +1,4 @@
-import { LLMOutputMatcher } from "@llm-ui/react/core";
+import { LLMOutputMatcher } from "@llm-ui/react";
 import { regexMatcher } from "@llm-ui/shared";
 
 export const findCompleteButtons = (): LLMOutputMatcher => {

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -17,16 +17,6 @@
         "default": "./dist/index.cjs"
       }
     },
-    "./shikiBundles/allLangs": {
-      "import": {
-        "types": "./dist/shikiBundles/allLangs.d.ts",
-        "default": "./dist/shikiBundles/allLangs.js"
-      },
-      "require": {
-        "types": "./dist/shikiBundles/allLangs.d.cts",
-        "default": "./dist/shikiBundles/allLangs.cjs"
-      }
-    },
     "./shikiBundles/allThemes": {
       "import": {
         "types": "./dist/shikiBundles/allThemes.d.ts",

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -16,16 +16,6 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./shikiBundles/allThemes": {
-      "import": {
-        "types": "./dist/shikiBundles/allThemes.d.ts",
-        "default": "./dist/shikiBundles/allThemes.js"
-      },
-      "require": {
-        "types": "./dist/shikiBundles/allThemes.d.cts",
-        "default": "./dist/shikiBundles/allThemes.cjs"
-      }
     }
   },
   "files": [

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -23,3 +23,7 @@ export type { UseCodeToHtmlParams } from "./hooks/useCodeToHtml";
 export { loadHighlighter } from "./hooks/useLoadHighlighter";
 
 export type { CodeToHtmlOptions, LLMUIHighlighter, ShikiProps } from "./types";
+
+export { allLangs, allLangsAlias } from "./shikiBundles/allLangs";
+
+export { allThemes } from "./shikiBundles/allThemes";

--- a/packages/code/src/lookBack.test.ts
+++ b/packages/code/src/lookBack.test.ts
@@ -1,4 +1,4 @@
-import { LookBack } from "@llm-ui/react/core";
+import { LookBack } from "@llm-ui/react";
 import { describe, expect, it } from "vitest";
 import { codeBlockLookBack } from "./lookBack";
 import { CodeBlockOptions } from "./options";

--- a/packages/code/src/lookBack.ts
+++ b/packages/code/src/lookBack.ts
@@ -1,4 +1,4 @@
-import { LookBackFunction } from "@llm-ui/react/core";
+import { LookBackFunction } from "@llm-ui/react";
 import { CodeBlockOptions, getOptions } from "./options";
 import {
   parseCompleteMarkdownCodeBlock,

--- a/packages/code/src/matchers.test.ts
+++ b/packages/code/src/matchers.test.ts
@@ -1,4 +1,4 @@
-import { MaybeLLMOutputMatch } from "@llm-ui/react/core";
+import { MaybeLLMOutputMatch } from "@llm-ui/react";
 import { describe, expect, it } from "vitest";
 import { findCompleteCodeBlock, findPartialCodeBlock } from "./matchers";
 import { CodeBlockOptions } from "./options";

--- a/packages/code/src/matchers.ts
+++ b/packages/code/src/matchers.ts
@@ -1,4 +1,4 @@
-import { LLMOutputMatcher } from "@llm-ui/react/core";
+import { LLMOutputMatcher } from "@llm-ui/react";
 import { CodeBlockOptions, getOptions } from "./options";
 
 import { regexMatcher } from "@llm-ui/shared";

--- a/packages/code/tsup.config.ts
+++ b/packages/code/tsup.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: [
-    "src/index.ts",
-    "src/shikiBundles/allLangs.ts",
-    "src/shikiBundles/allThemes.ts",
-  ],
+  entry: ["src/index.ts"],
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/packages/markdown/src/lookBack.ts
+++ b/packages/markdown/src/lookBack.ts
@@ -1,4 +1,4 @@
-import { LookBackFunction } from "@llm-ui/react/core";
+import { LookBackFunction } from "@llm-ui/react";
 import {
   markdownToVisibleText,
   markdownWithVisibleChars,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,34 +4,14 @@
   "type": "module",
   "exports": {
     "./package.json": "./package.json",
-    "./core": {
+    ".": {
       "import": {
-        "types": "./dist/core/index.d.ts",
-        "default": "./dist/core/index.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/core/index.d.cts",
-        "default": "./dist/core/index.cjs"
-      }
-    },
-    "./examples": {
-      "import": {
-        "types": "./dist/examples/index.d.ts",
-        "default": "./dist/examples/index.js"
-      },
-      "require": {
-        "types": "./dist/examples/index.d.cts",
-        "default": "./dist/examples/index.cjs"
-      }
-    },
-    "./throttle": {
-      "import": {
-        "types": "./dist/throttle/index.d.ts",
-        "default": "./dist/throttle/index.js"
-      },
-      "require": {
-        "types": "./dist/throttle/index.d.cts",
-        "default": "./dist/throttle/index.cjs"
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./core";
+export * from "./examples";
+export * from "./throttle";

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: [
-    "src/core/index.ts",
-    "src/examples/index.ts",
-    "src/throttle/index.ts",
-  ],
+  entry: ["src/index.ts"],
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/packages/shared/src/regexMatcher.ts
+++ b/packages/shared/src/regexMatcher.ts
@@ -1,4 +1,4 @@
-import { MaybeLLMOutputMatch } from "@llm-ui/react/core";
+import { MaybeLLMOutputMatch } from "@llm-ui/react";
 
 export const regexMatcher =
   (regex: RegExp) =>


### PR DESCRIPTION
Fixes: #169

`@llm-ui/react/{core,examples,throttle}` -> `@llm-ui/react`
`@llm-ui/code/shikiBundles/{allLangs,allThemes}` -> `@llm-ui/code`

Removes exports more than one level deep (e.g. `@llm-ui/react/core`) since they don't work with older moduleResolution settings in TypeScript (which react-script uses by default).