### PR TITLE
useLLmOutput slow & restart bug fixes

### DIFF
--- a/.changeset/famous-jars-speak.md
+++ b/.changeset/famous-jars-speak.md
@@ -2,6 +2,7 @@
 "@llm-ui/react": minor
 ---
 
-useLLMOutput only starts streaming when llmOutput is not empty. Resets if llmOutput is later set to empty.
-
-This fixes bugs where the streamed output is slow.
+- `useLLMOutput` only starts streaming when llmOutput is not empty.
+  - This fixes bugs where the streamed output is slow
+- `useLLMOutput` reset its state if `llmOutput` is later set to `""`.
+  - This allows `useLLMOutput` to be reused more than once

--- a/.changeset/famous-jars-speak.md
+++ b/.changeset/famous-jars-speak.md
@@ -1,0 +1,7 @@
+---
+"@llm-ui/react": minor
+---
+
+useLLMOutput only starts streaming when llmOutput is not empty. Resets if llmOutput is later set to empty.
+
+This fixes bugs where the streamed output is slow.


### PR DESCRIPTION
- `useLLMOutput` only starts streaming when llmOutput is not empty. 
  - This fixes bugs where the streamed output is slow 
- `useLLMOutput` reset its state if `llmOutput` is later set to `""`.
  - This allows `useLLMOutput` to be reused more than once


