### PR TITLE
Custom blocks fixes

### DIFF
--- a/.changeset/chilly-melons-buy.md
+++ b/.changeset/chilly-melons-buy.md
@@ -1,0 +1,5 @@
+---
+"@llm-ui/markdown": minor
+---
+
+Markdown visible text no longer includes \n. This was causing behavior that was difficult to predict.

--- a/.changeset/cuddly-ads-wink.md
+++ b/.changeset/cuddly-ads-wink.md
@@ -1,0 +1,5 @@
+---
+"@llm-ui/custom": minor
+---
+
+b

--- a/.changeset/cuddly-ads-wink.md
+++ b/.changeset/cuddly-ads-wink.md
@@ -2,4 +2,7 @@
 "@llm-ui/custom": minor
 ---
 
-b
+- New options:
+  - defaultVisible: false,
+  - visibleKeyPaths: [],
+  - invisibleKeyPaths: [],

--- a/.changeset/stale-flowers-matter.md
+++ b/.changeset/stale-flowers-matter.md
@@ -1,0 +1,6 @@
+---
+"@llm-ui/react": minor
+---
+
+- `useLLMOutput` hook now returns all known blocks, it doesn't truncate the blocks based on how much is visible.
+- `isVisible: true|false` added to 'blockMatch' returned from `useLLMOutput` hook.

--- a/apps/www/src/components/examples/Buttons.tsx
+++ b/apps/www/src/components/examples/Buttons.tsx
@@ -7,12 +7,13 @@ import { Button } from "../ui/Button";
 
 type OnClick = (buttonText: string | undefined) => void;
 
-const schema = z.object({
+const partialSchema = z.object({
   type: z.literal("buttons"),
-  buttons: z.array(z.object({ text: z.string() })),
+  buttons: z
+    .array(z.object({ text: z.string().nullable().optional() }))
+    .nullable()
+    .optional(),
 });
-
-const partialSchema = schema.deepPartial();
 
 const buttonsComponent = (onClick: OnClick) => {
   const ButtonsComponent: LLMOutputComponent = ({ blockMatch }) => {
@@ -44,6 +45,6 @@ export const starsAndConfetti = (buttonText: string = "") => {
 export const buttonsBlock = (
   onClick: OnClick = starsAndConfetti,
 ): LLMOutputBlock => ({
-  ...customBlock("buttons"),
+  ...customBlock("buttons", { defaultVisible: true }),
   component: buttonsComponent(onClick),
 });

--- a/apps/www/src/components/examples/Buttons.tsx
+++ b/apps/www/src/components/examples/Buttons.tsx
@@ -18,13 +18,13 @@ const partialSchema = z.object({
 const buttonsComponent = (onClick: OnClick) => {
   const ButtonsComponent: LLMOutputComponent = ({ blockMatch }) => {
     const buttons = partialSchema.parse(parseJson5(blockMatch.output));
-    if (!buttons) {
+    if (!buttons || !blockMatch.isVisible) {
       return undefined;
     }
     return (
       <div className="flex flex-row my-4 gap-2">
         {buttons?.buttons?.map((button, index) => (
-          <Button key={index} onClick={() => onClick(button?.text)}>
+          <Button key={index} onClick={() => onClick(button?.text ?? "")}>
             {button?.text}
           </Button>
         ))}

--- a/examples/custom-components/nextjs/src/app/page.tsx
+++ b/examples/custom-components/nextjs/src/app/page.tsx
@@ -39,7 +39,7 @@ const MarkdownComponent: LLMOutputComponent = ({ blockMatch }) => {
 
 // Customize this component with your own styling
 const ButtonsComponent: LLMOutputComponent = ({ blockMatch }) => {
-  const isVisible = blockMatch.visibleText.length > 0;
+  const isVisible = blockMatch.isVisible;
   if (!isVisible) {
     return null;
   }

--- a/examples/custom-components/vite/src/App.tsx
+++ b/examples/custom-components/vite/src/App.tsx
@@ -39,7 +39,7 @@ const MarkdownComponent: LLMOutputComponent = ({ blockMatch }) => {
 
 // Customize this component with your own styling
 const ButtonsComponent: LLMOutputComponent = ({ blockMatch }) => {
-  const isVisible = blockMatch.visibleText.length > 0;
+  const isVisible = blockMatch.isVisible;
   if (!isVisible) {
     return null;
   }

--- a/examples/vercel-ai/nextjs/package.json
+++ b/examples/vercel-ai/nextjs/package.json
@@ -14,7 +14,7 @@
     "@llm-ui/code": "^0.7.0",
     "@llm-ui/markdown": "^0.7.0",
     "@llm-ui/react": "^0.7.0",
-    "ai": "^3.1.13",
+    "ai": "^3.1.14",
     "html-react-parser": "^5.1.10",
     "next": "14.2.3",
     "react": "^18",

--- a/packages/custom/src/jsonPathTraverse.test.ts
+++ b/packages/custom/src/jsonPathTraverse.test.ts
@@ -1,27 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { traverseLeafNodesWithIgnores } from "./jsonPathTraverse";
+import {
+  IsPathAllowedFunction,
+  isAllowed,
+  isIgnored,
+  traverseLeafNodes,
+} from "./jsonPathTraverse";
 
 type TestCase = {
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   jsonObject: any;
-  ignorePaths: string[];
+  isPathAllowed: IsPathAllowedFunction;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expected: { node: any; path: string }[];
 };
 
-describe("traverseLeafNodesWithIgnores", () => {
+describe("traverseLeafNodes", () => {
   const testCases: TestCase[] = [
+    // allowed
     {
       name: "{ a: 1 }",
       jsonObject: { a: 1 },
-      ignorePaths: [],
+      isPathAllowed: isAllowed(["$.a"]),
       expected: [{ node: 1, path: "$.a" }],
     },
     {
       name: "{ a: 1, b: 2 }",
       jsonObject: { a: 1, b: 2 },
-      ignorePaths: [],
+      isPathAllowed: isAllowed(["$.a", "$.b"]),
       expected: [
         { node: 1, path: "$.a" },
         { node: 2, path: "$.b" },
@@ -30,31 +36,90 @@ describe("traverseLeafNodesWithIgnores", () => {
     {
       name: "nested objects",
       jsonObject: { a: { b: 2 } },
-      ignorePaths: [],
+      isPathAllowed: isAllowed(["$.a.b"]),
       expected: [{ node: 2, path: "$.a.b" }],
     },
     {
       name: "array",
       jsonObject: { a: [{ b: 2 }] },
-      ignorePaths: [],
+      isPathAllowed: isAllowed(["$.a[*].b"]),
+      expected: [{ node: 2, path: "$.a[0].b" }],
+    },
+    {
+      name: "allow root key",
+      jsonObject: { a: 1, b: 2 },
+      isPathAllowed: isAllowed(["$.b"]),
+      expected: [{ node: 2, path: "$.b" }],
+    },
+    {
+      name: "allow nested key",
+      jsonObject: { a: { b: 2, c: 3 } },
+      isPathAllowed: isAllowed(["$.a.c"]),
+      expected: [{ node: 3, path: "$.a.c" }],
+    },
+    {
+      name: "allow nested key in array",
+      jsonObject: {
+        a: [
+          { b: 1, c: 2 },
+          { b: 3, c: 4 },
+        ],
+      },
+      isPathAllowed: isAllowed(["$.a[*].c"]),
+      expected: [
+        { node: 2, path: "$.a[0].c" },
+        {
+          node: 4,
+          path: "$.a[1].c",
+        },
+      ],
+    },
+
+    // ignores
+
+    {
+      name: "{ a: 1 }",
+      jsonObject: { a: 1 },
+      isPathAllowed: isIgnored([]),
+      expected: [{ node: 1, path: "$.a" }],
+    },
+    {
+      name: "{ a: 1, b: 2 }",
+      jsonObject: { a: 1, b: 2 },
+      isPathAllowed: isIgnored([]),
+      expected: [
+        { node: 1, path: "$.a" },
+        { node: 2, path: "$.b" },
+      ],
+    },
+    {
+      name: "nested objects",
+      jsonObject: { a: { b: 2 } },
+      isPathAllowed: isIgnored([]),
+      expected: [{ node: 2, path: "$.a.b" }],
+    },
+    {
+      name: "array",
+      jsonObject: { a: [{ b: 2 }] },
+      isPathAllowed: isIgnored([]),
       expected: [{ node: 2, path: "$.a[0].b" }],
     },
     {
       name: "ignore root key",
       jsonObject: { a: 1, b: 2 },
-      ignorePaths: ["$.a"],
+      isPathAllowed: isIgnored(["$.a"]),
       expected: [{ node: 2, path: "$.b" }],
     },
     {
       name: "ignore root key of nested object",
       jsonObject: { a: { b: 2 } },
-      ignorePaths: ["$.a"],
+      isPathAllowed: isIgnored(["$.a"]),
       expected: [],
     },
     {
       name: "ignore nested key",
       jsonObject: { a: { b: 2, c: 3 } },
-      ignorePaths: ["$.a.b"],
+      isPathAllowed: isIgnored(["$.a.b"]),
       expected: [{ node: 3, path: "$.a.c" }],
     },
     {
@@ -65,7 +130,7 @@ describe("traverseLeafNodesWithIgnores", () => {
           { b: 3, c: 4 },
         ],
       },
-      ignorePaths: ["$.a[*].b"],
+      isPathAllowed: isIgnored(["$.a[*].b"]),
       expected: [
         { node: 2, path: "$.a[0].c" },
         {
@@ -76,10 +141,10 @@ describe("traverseLeafNodesWithIgnores", () => {
     },
   ];
 
-  testCases.forEach(({ name, jsonObject, ignorePaths, expected }) => {
+  testCases.forEach(({ name, jsonObject, isPathAllowed, expected }) => {
     it(name, () => {
       const result: TestCase["expected"] = [];
-      traverseLeafNodesWithIgnores(jsonObject, ignorePaths, (node, path) => {
+      traverseLeafNodes(jsonObject, isPathAllowed, (node, path) => {
         result.push({ node, path });
       });
       expect(result).toEqual(expected);

--- a/packages/custom/src/jsonPathTraverse.ts
+++ b/packages/custom/src/jsonPathTraverse.ts
@@ -3,22 +3,18 @@
 import { JSONPath } from "jsonpath-plus";
 import { JsonAny } from "./types";
 
-/**
- * Traverses a JSON object or array, applying a callback function to each leaf node that is not ignored.
- *
- * @param jsonObject The JSON object or array to traverse.
- * @param ignorePaths An array of JSONPath strings specifying the paths to ignore.
- * @param callback A function to call for each non-ignored leaf node. Receives the node and its path.
- */
-export const traverseLeafNodesWithIgnores = (
+export type IsPathAllowedFunction = (
+  pathPointers: string[],
   jsonObject: JsonAny,
-  ignorePaths: string[],
+  isLeaf: boolean,
+) => boolean;
+
+export const traverseLeafNodes = (
+  jsonObject: JsonAny,
+  isPathAllowed: IsPathAllowedFunction,
   callback: (node: any, path: string) => void,
 ): void => {
   const traverse = (currentObject: JsonAny, currentPath: string) => {
-    if (isIgnored(currentPath)) {
-      return; // Skip this path if it's meant to be ignored
-    }
     if (currentObject !== null && typeof currentObject === "object") {
       // If it's an object or array, continue traversing
       if (
@@ -27,10 +23,13 @@ export const traverseLeafNodesWithIgnores = (
         (Array.isArray(currentObject) && currentObject.length === 0)
       ) {
         // Empty object or array, treat as a leaf
-        if (!isIgnored(currentPath)) {
+        if (shouldTraverse(currentPath, true)) {
           callback(currentObject, currentPath);
         }
       } else {
+        if (!shouldTraverse(currentPath, false)) {
+          return; // Skip this path if it's meant to be ignored
+        }
         Object.entries(currentObject).forEach(([key, value]) => {
           traverse(
             value,
@@ -40,29 +39,52 @@ export const traverseLeafNodesWithIgnores = (
       }
     } else {
       // Current object is a leaf (primitive or null)
-      if (!isIgnored(currentPath)) {
+      if (shouldTraverse(currentPath, true)) {
         callback(currentObject, currentPath);
       }
     }
   };
 
-  const isIgnored = (path: string) => {
+  const shouldTraverse = (path: string, isLeaf: boolean) => {
     const pathPointer: string[] = JSONPath({
       path: path,
       json: jsonObject,
       resultType: "pointer",
     });
-    return ignorePaths.some((ignorePath) => {
-      const ignoredNodes = JSONPath({
-        path: ignorePath,
-        json: jsonObject,
-        resultType: "pointer",
-      });
-      return ignoredNodes.some((pointer: any) =>
-        pathPointer.some((p) => p === pointer),
-      );
-    });
+    return isPathAllowed(pathPointer, jsonObject, isLeaf);
   };
 
   traverse(jsonObject, "$"); // Start from the root
 };
+
+export const isAllowed =
+  (allowPaths: string[]) =>
+  (pathPointers: string[], jsonObject: JsonAny, isLeaf: boolean) => {
+    return (
+      !isLeaf ||
+      allowPaths.some((allowPath) => {
+        const allowPathPointers = JSONPath({
+          path: allowPath,
+          json: jsonObject,
+          resultType: "pointer",
+        });
+        return allowPathPointers.some((app: any) =>
+          pathPointers.some((p) => p === app),
+        );
+      })
+    );
+  };
+
+export const isIgnored =
+  (ignorePaths: string[]) => (pathPointers: string[], jsonObject: JsonAny) => {
+    return !ignorePaths.some((ignorePath) => {
+      const ignorePathPointers = JSONPath({
+        path: ignorePath,
+        json: jsonObject,
+        resultType: "pointer",
+      });
+      return ignorePathPointers.some((app: any) =>
+        pathPointers.some((p) => p === app),
+      );
+    });
+  };

--- a/packages/custom/src/lookback.test.ts
+++ b/packages/custom/src/lookback.test.ts
@@ -121,6 +121,18 @@ describe("customBlockLookBack", () => {
       },
     },
     {
+      name: "partial excludeVisibleKeys",
+      output: '【{type:"buttons", something',
+      options: { defaultVisible: true },
+      isStreamFinished: false,
+      isComplete: false,
+      visibleTextLengthTarget: 3,
+      expected: {
+        output: JSON.stringify({ type: "buttons", something: null }, null, 2),
+        visibleText: "",
+      },
+    },
+    {
       name: "partial",
       output: '【{type:"buttons", something: "123',
       isStreamFinished: false,

--- a/packages/custom/src/lookback.test.ts
+++ b/packages/custom/src/lookback.test.ts
@@ -20,14 +20,56 @@ describe("customBlockLookBack", () => {
       output: '【{type:"buttons", something: "1234", else: "5678"}】',
       isStreamFinished: true,
       isComplete: true,
-      visibleTextLengthTarget: 8,
+      visibleTextLengthTarget: 1,
       expected: {
         output: JSON.stringify(
           { type: "buttons", something: "1234", else: "5678" },
           null,
           2,
         ),
-        visibleText: "12345678",
+        visibleText: " ",
+      },
+    },
+    {
+      name: "full no visible text",
+      output: '【{type:"buttons", something: "1234", else: "5678"}】',
+      isStreamFinished: true,
+      isComplete: true,
+      visibleTextLengthTarget: 0,
+      expected: {
+        output: JSON.stringify(
+          { type: "buttons", something: "1234", else: "5678" },
+          null,
+          2,
+        ),
+        visibleText: "",
+      },
+    },
+
+    {
+      name: "partial",
+      output: '【{type:"buttons", something: "1234", else: "',
+      isStreamFinished: false,
+      isComplete: false,
+      visibleTextLengthTarget: 1,
+      expected: {
+        output: JSON.stringify(
+          { type: "buttons", something: "1234", else: "" },
+          null,
+          2,
+        ),
+        visibleText: "",
+      },
+    },
+    {
+      name: "partial2",
+      output: '【{type:"buttons"',
+      isStreamFinished: false,
+      isComplete: false,
+      visibleTextLengthTarget: 1,
+      expected: {
+        output: JSON.stringify({ type: "buttons" }, null, 2),
+        visibleText: "",
       },
     },
     {
@@ -36,9 +78,26 @@ describe("customBlockLookBack", () => {
       isStreamFinished: true,
       isComplete: true,
       visibleTextLengthTarget: 3,
+      options: { visibleKeyPaths: ["$.something"] },
       expected: {
         output: JSON.stringify(
-          { type: "buttons", something: "123", else: "" },
+          { type: "buttons", something: "123", else: "5678" },
+          null,
+          2,
+        ),
+        visibleText: "123",
+      },
+    },
+    {
+      name: "visibleKeyPaths",
+      output: '【{type:"buttons", something: "1234", else: "5678"}】',
+      options: { visibleKeyPaths: ["$.something"] },
+      isStreamFinished: true,
+      isComplete: true,
+      visibleTextLengthTarget: 3,
+      expected: {
+        output: JSON.stringify(
+          { type: "buttons", something: "123", else: "5678" },
           null,
           2,
         ),
@@ -48,7 +107,7 @@ describe("customBlockLookBack", () => {
     {
       name: "excludeVisibleKeys",
       output: '【{type:"buttons", something: "1234", else: "5678"}】',
-      options: { invisibleKeyPaths: ["$.else"] },
+      options: { defaultVisible: true, invisibleKeyPaths: ["$.else"] },
       isStreamFinished: true,
       isComplete: true,
       visibleTextLengthTarget: 3,
@@ -66,6 +125,7 @@ describe("customBlockLookBack", () => {
       output: '【{type:"buttons", something: "123',
       isStreamFinished: false,
       isComplete: false,
+      options: { visibleKeyPaths: ["$.something"] },
       visibleTextLengthTarget: 2,
       expected: {
         output: JSON.stringify({ type: "buttons", something: "12" }, null, 2),
@@ -78,7 +138,7 @@ describe("customBlockLookBack", () => {
       isStreamFinished: false,
       isComplete: false,
       visibleTextLengthTarget: 2,
-      options: { typeKey: "t" },
+      options: { typeKey: "t", visibleKeyPaths: ["$.something"] },
       expected: {
         output: JSON.stringify({ t: "buttons", something: "12" }, null, 2),
         visibleText: "12",

--- a/packages/custom/src/lookback.ts
+++ b/packages/custom/src/lookback.ts
@@ -1,6 +1,6 @@
 import { LookBackFunction } from "@llm-ui/react";
 import { setJsonPath } from "./jsonPathSet";
-import { traverseLeafNodesWithIgnores } from "./jsonPathTraverse";
+import { isAllowed, isIgnored, traverseLeafNodes } from "./jsonPathTraverse";
 import { CustomBlockOptions, getOptions } from "./options";
 import { parseJson5 } from "./parseJson5";
 import { removeStartEndChars } from "./shared";
@@ -10,17 +10,21 @@ export const customBlockLookBack = (
   userOptions?: Partial<CustomBlockOptions>,
 ): LookBackFunction => {
   const options = getOptions(userOptions);
-  const { invisibleKeyPaths, typeKey } = options;
-  return ({ output, visibleTextLengthTarget }) => {
+  const { typeKey, defaultVisible, visibleKeyPaths, invisibleKeyPaths } =
+    options;
+  return ({ output, visibleTextLengthTarget, isComplete }) => {
     const object = parseJson5(removeStartEndChars(output, options));
     if (!object || object[typeKey] !== type) {
       return { output: "", visibleText: "" };
     }
-    const invisiblePaths = [`$.${typeKey}`, ...invisibleKeyPaths];
     let remainingChars = visibleTextLengthTarget;
 
     let visibleText = "";
-    traverseLeafNodesWithIgnores(object, invisiblePaths, (value, path) => {
+    const shouldTraverse = defaultVisible
+      ? isIgnored([`$.${typeKey}`, ...invisibleKeyPaths])
+      : isAllowed(visibleKeyPaths);
+
+    traverseLeafNodes(object, shouldTraverse, (value, path) => {
       const valueString = `${value}`;
       const chars = Math.min(remainingChars, valueString.length);
       const valueVisible = valueString.slice(0, chars);
@@ -29,9 +33,15 @@ export const customBlockLookBack = (
       remainingChars -= chars;
     });
 
+    const isStreamingKeys = defaultVisible || visibleKeyPaths.length > 0;
+
     return {
       output: JSON.stringify(object, null, 2),
-      visibleText,
+      visibleText: isStreamingKeys
+        ? visibleText
+        : isComplete && visibleTextLengthTarget > 0
+          ? " " // Show a space if the block is complete and there is no visible text
+          : "",
     };
   };
 };

--- a/packages/custom/src/lookback.ts
+++ b/packages/custom/src/lookback.ts
@@ -25,12 +25,14 @@ export const customBlockLookBack = (
       : isAllowed(visibleKeyPaths);
 
     traverseLeafNodes(object, shouldTraverse, (value, path) => {
-      const valueString = `${value}`;
-      const chars = Math.min(remainingChars, valueString.length);
-      const valueVisible = valueString.slice(0, chars);
-      visibleText += valueVisible;
-      setJsonPath(object, path, valueVisible);
-      remainingChars -= chars;
+      if (typeof value === "string") {
+        const valueString = `${value}`;
+        const chars = Math.min(remainingChars, valueString.length);
+        const valueVisible = valueString.slice(0, chars);
+        visibleText += valueVisible;
+        setJsonPath(object, path, valueVisible);
+        remainingChars -= chars;
+      }
     });
 
     const isStreamingKeys = defaultVisible || visibleKeyPaths.length > 0;

--- a/packages/custom/src/matchers.test.ts
+++ b/packages/custom/src/matchers.test.ts
@@ -65,6 +65,16 @@ describe("findCompleteCustomBlock", () => {
       },
     },
     {
+      name: "full custom component with fields sandwiched",
+      input:
+        'the start【{type:"buttons", something: "something", else: "else"}】keeps going',
+      expected: {
+        startIndex: 9,
+        endIndex: 65,
+        outputRaw: '【{type:"buttons", something: "something", else: "else"}】',
+      },
+    },
+    {
       name: "custom type key",
       input: '【{t:"buttons", something: "something", else: "else"}】',
       options: {

--- a/packages/custom/src/matchers.ts
+++ b/packages/custom/src/matchers.ts
@@ -12,11 +12,13 @@ const findCustomBlock = (
   const matcher = regexMatcher(regex);
   return (llmOutput: string) => {
     const match = matcher(llmOutput);
-    if (match) {
-      const block = parseJson5(removeStartEndChars(match.outputRaw, options));
-      if (!block || block[options.typeKey] !== type) {
-        return undefined;
-      }
+    if (!match) {
+      return undefined;
+    }
+    const block = parseJson5(removeStartEndChars(match.outputRaw, options));
+
+    if (!block || block[options.typeKey] !== type) {
+      return undefined;
     }
     return match;
   };

--- a/packages/custom/src/options.ts
+++ b/packages/custom/src/options.ts
@@ -1,6 +1,8 @@
 export type CustomBlockOptions = {
   startChar: string;
   endChar: string;
+  defaultVisible: boolean;
+  visibleKeyPaths: string[];
   invisibleKeyPaths: string[];
   typeKey: string;
 };
@@ -8,6 +10,8 @@ export type CustomBlockOptions = {
 export const defaultOptions: CustomBlockOptions = {
   startChar: "【",
   endChar: "】",
+  defaultVisible: false,
+  visibleKeyPaths: [],
   invisibleKeyPaths: [],
   typeKey: "type",
 };

--- a/packages/markdown/src/markdownParser.test.ts
+++ b/packages/markdown/src/markdownParser.test.ts
@@ -298,22 +298,22 @@ describe("markdownToVisibleText", () => {
 
     // ambiguous so we don't show it yet.
     { input: "*", isFinished: false, expected: "" },
-    { input: "abc\n*", isFinished: false, expected: "abc\n" },
+    { input: "abc\n*", isFinished: false, expected: "abc" },
     { input: "*abc", isFinished: false, expected: "" },
     { input: "__abc", isFinished: false, expected: "" },
     { input: "~~~abc", isFinished: false, expected: "" },
     // weird incorrect syntax (*a should be * a)
     { input: "*abc\n", isFinished: false, expected: "" },
-    { input: "*abc\ndef", isFinished: false, expected: "*abc\ndef" },
-    { input: "*abc\ndef*", isFinished: false, expected: "abc\ndef" },
+    { input: "*abc\ndef", isFinished: false, expected: "*abcdef" },
+    { input: "*abc\ndef*", isFinished: false, expected: "abcdef" },
     { input: "*abc\n**def*", isFinished: false, expected: "" }, // broken
     // ambiguous, but isFinished true so we don't hide things
     { input: "*", isFinished: true, expected: "*" },
     { input: "*abc", isFinished: true, expected: "*abc" },
     { input: "*abc\n", isFinished: true, expected: "*abc" },
-    { input: "*abc\ndef", isFinished: true, expected: "*abc\ndef" },
-    { input: "*abc\n**def**", isFinished: true, expected: "*abc\ndef" },
-    { input: "*abc\ndef*", isFinished: true, expected: "abc\ndef" }, // weird syntax edge case
+    { input: "*abc\ndef", isFinished: true, expected: "*abcdef" },
+    { input: "*abc\n**def**", isFinished: true, expected: "*abcdef" },
+    { input: "*abc\ndef*", isFinished: true, expected: "abcdef" }, // weird syntax edge case
     { input: "*abc* *def*", isFinished: true, expected: "abc def" },
 
     // thematic breaks
@@ -360,7 +360,7 @@ describe("markdownToVisibleText", () => {
     // paragraphs
 
     { input: "abc\n", isFinished: false, expected: "abc" },
-    { input: "abc\ndef", isFinished: false, expected: "abc\ndef" }, // mdast seems to see this as a single paragraph in the ast
+    { input: "abc\ndef", isFinished: false, expected: "abcdef" }, // mdast seems to see this as a single paragraph in the ast
     { input: "abc\n\ndef", isFinished: false, expected: "abcdef" },
 
     // list items
@@ -799,6 +799,20 @@ describe("markdownWithVisibleChars", () => {
       visibleChars: 2,
       expected: "`ab`\n",
     },
+
+    // trailing newlines
+    {
+      markdown: "abc\nd",
+      isFinished: false,
+      visibleChars: 3,
+      expected: "abc\n",
+    },
+    {
+      markdown: "abc\nd",
+      isFinished: false,
+      visibleChars: 4,
+      expected: "abc\nd\n",
+    },
   ];
 
   testCases.forEach(({ markdown, visibleChars, isFinished, expected }) => {
@@ -822,7 +836,13 @@ describe("markdownWithVisibleChars", () => {
         visibleChars,
         originalVisibleText.length,
       );
-      expect(visibleText.length).toBe(expectedVisibleChars);
+      try {
+        expect(visibleText.length).toBe(expectedVisibleChars);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (e: any) {
+        e.message = `${e.message} visibleText: ${visibleText}`;
+        throw e;
+      }
     });
   });
 });

--- a/packages/markdown/src/markdownParser.ts
+++ b/packages/markdown/src/markdownParser.ts
@@ -200,7 +200,9 @@ const markdownAstToVisibleText = (markdownAst: Root, isFinished: boolean) => {
   if (!isFinished) {
     removePartialAmbiguousMarkdownFromAst(markdownAst);
   }
-  return removeZeroWidthSpaces(markdownAstToVisibleTextHelper(markdownAst));
+  return removeZeroWidthSpaces(
+    markdownAstToVisibleTextHelper(markdownAst),
+  ).replaceAll("\n", "");
 };
 
 export const markdownToVisibleText = (
@@ -290,7 +292,6 @@ export const markdownWithVisibleChars = (
     removePartialAmbiguousMarkdownFromAst(markdownAst);
   }
   const visibleText = markdownAstToVisibleText(markdownAst, isFinished);
-
   const charsToRemove = visibleText.length - visibleChars;
   removeVisibleCharsFromAst(markdownAst, charsToRemove);
   return astToMarkdown(markdownAst);

--- a/packages/markdown/src/markdownParser.ts
+++ b/packages/markdown/src/markdownParser.ts
@@ -203,6 +203,7 @@ const markdownAstToVisibleText = (markdownAst: Root, isFinished: boolean) => {
   return removeZeroWidthSpaces(
     markdownAstToVisibleTextHelper(markdownAst),
   ).replaceAll("\n", "");
+  // mdast is not reliable with \n so we remove them all
 };
 
 export const markdownToVisibleText = (

--- a/packages/react/src/core/useLLMOutput/helper.test.tsx
+++ b/packages/react/src/core/useLLMOutput/helper.test.tsx
@@ -79,6 +79,7 @@ describe("matchBlocks", () => {
           block: fallbackBlock,
           outputRaw: "helloWorld",
           visibleText: "helloWorld",
+          isVisible: true,
           output:
             "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
           startIndex: 0,
@@ -101,6 +102,7 @@ describe("matchBlocks", () => {
           block: fallbackBlock,
           outputRaw: "helloWorld",
           visibleText: "helloWorld",
+          isVisible: true,
           output:
             "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
           startIndex: 0,
@@ -125,6 +127,7 @@ describe("matchBlocks", () => {
             block: block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:99 isStreamFinished:true",
             startIndex: 0,
@@ -150,6 +153,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "hel",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:3 isStreamFinished:true",
             startIndex: 0,
@@ -175,6 +179,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "hel",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:3 isStreamFinished:true",
             startIndex: 0,
@@ -187,6 +192,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "",
+            isVisible: false,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:0 isStreamFinished:true",
             startIndex: 10,
@@ -212,6 +218,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -224,6 +231,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:90 isStreamFinished:true",
             startIndex: 10,
@@ -250,6 +258,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -262,6 +271,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "fallback",
             visibleText: "fallback",
+            isVisible: true,
             output:
               "fallback isComplete:true visibleTextLengthTarget:90 isStreamFinished:true",
             startIndex: 10,
@@ -274,6 +284,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:82 isStreamFinished:true",
             startIndex: 18,
@@ -299,6 +310,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -311,6 +323,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: " world",
             visibleText: " world",
+            isVisible: true,
             output:
               " world isComplete:true visibleTextLengthTarget:90 isStreamFinished:true",
             startIndex: 10,
@@ -336,6 +349,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -348,6 +362,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: " world",
             visibleText: " world",
+            isVisible: true,
             output:
               " world isComplete:true visibleTextLengthTarget:90 isStreamFinished:true",
             startIndex: 10,
@@ -373,6 +388,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "helloWorld",
             visibleText: "hel",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:3 isStreamFinished:true",
             startIndex: 0,
@@ -385,6 +401,7 @@ describe("matchBlocks", () => {
             block: block,
             outputRaw: " world",
             visibleText: "",
+            isVisible: false,
             output:
               " world isComplete:true visibleTextLengthTarget:0 isStreamFinished:true",
             startIndex: 10,
@@ -410,6 +427,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "hell",
             visibleText: "hell",
+            isVisible: true,
             output:
               "hell isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -422,6 +440,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "oWo",
             visibleText: "oWo",
+            isVisible: true,
             output:
               "oWo isComplete:true visibleTextLengthTarget:96 isStreamFinished:true",
             startIndex: 4,
@@ -434,6 +453,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "rld world",
             visibleText: "rld world",
+            isVisible: true,
             output:
               "rld world isComplete:true visibleTextLengthTarget:93 isStreamFinished:true",
             startIndex: 7,
@@ -459,6 +479,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -471,6 +492,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: " world",
             visibleText: " world",
+            isVisible: true,
             output:
               " world isComplete:true visibleTextLengthTarget:90 isStreamFinished:true",
             startIndex: 10,
@@ -497,6 +519,7 @@ describe("matchBlocks", () => {
             block: block1,
             outputRaw: "hello",
             visibleText: "hello",
+            isVisible: true,
             output:
               "hello isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -509,6 +532,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "World",
             visibleText: "World",
+            isVisible: true,
             output:
               "World isComplete:true visibleTextLengthTarget:95 isStreamFinished:true",
             startIndex: 5,
@@ -535,6 +559,7 @@ describe("matchBlocks", () => {
             block: block1,
             outputRaw: "hello",
             visibleText: "hello",
+            isVisible: true,
             output:
               "hello isComplete:true visibleTextLengthTarget:100 isStreamFinished:true",
             startIndex: 0,
@@ -547,6 +572,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "World",
             visibleText: "World",
+            isVisible: true,
             output:
               "World isComplete:true visibleTextLengthTarget:95 isStreamFinished:true",
             startIndex: 5,
@@ -572,6 +598,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "helloWorld",
+            isVisible: true,
             output:
               "helloWorld isComplete:false visibleTextLengthTarget:100 isStreamFinished:false",
             startIndex: 0,
@@ -597,6 +624,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "helloWorld",
             visibleText: "hel",
+            isVisible: true,
             output:
               "helloWorld isComplete:false visibleTextLengthTarget:3 isStreamFinished:false",
             startIndex: 0,
@@ -622,6 +650,7 @@ describe("matchBlocks", () => {
             block: fallbackBlock,
             outputRaw: "hello",
             visibleText: "hello",
+            isVisible: true,
             output:
               "hello isComplete:true visibleTextLengthTarget:100 isStreamFinished:false",
             startIndex: 0,
@@ -634,6 +663,7 @@ describe("matchBlocks", () => {
             block,
             outputRaw: "World",
             visibleText: "World",
+            isVisible: true,
             output:
               "World isComplete:false visibleTextLengthTarget:95 isStreamFinished:false",
             startIndex: 5,
@@ -660,6 +690,7 @@ describe("matchBlocks", () => {
             block: completeBlock,
             outputRaw: "hello",
             visibleText: "hello",
+            isVisible: true,
             output:
               "hello isComplete:true visibleTextLengthTarget:100 isStreamFinished:false",
             startIndex: 0,
@@ -672,6 +703,7 @@ describe("matchBlocks", () => {
             block: partialBlock,
             outputRaw: "World",
             visibleText: "World",
+            isVisible: true,
             output:
               "World isComplete:false visibleTextLengthTarget:95 isStreamFinished:false",
             startIndex: 5,

--- a/packages/react/src/core/useLLMOutput/helper.test.tsx
+++ b/packages/react/src/core/useLLMOutput/helper.test.tsx
@@ -183,6 +183,18 @@ describe("matchBlocks", () => {
             llmOutput: "helloWorldhelloWorld",
             isComplete: true,
           },
+          {
+            block,
+            outputRaw: "helloWorld",
+            visibleText: "",
+            output:
+              "helloWorld isComplete:true visibleTextLengthTarget:0 isStreamFinished:true",
+            startIndex: 10,
+            endIndex: 20,
+            priority: 0,
+            llmOutput: "helloWorldhelloWorld",
+            isComplete: true,
+          },
         ],
       } satisfies TestCase;
     },
@@ -366,6 +378,18 @@ describe("matchBlocks", () => {
             startIndex: 0,
             endIndex: 10,
             priority: 1,
+            llmOutput: "helloWorld world",
+            isComplete: true,
+          },
+          {
+            block: block,
+            outputRaw: " world",
+            visibleText: "",
+            output:
+              " world isComplete:true visibleTextLengthTarget:0 isStreamFinished:true",
+            startIndex: 10,
+            endIndex: 16,
+            priority: 0,
             llmOutput: "helloWorld world",
             isComplete: true,
           },

--- a/packages/react/src/core/useLLMOutput/helper.ts
+++ b/packages/react/src/core/useLLMOutput/helper.ts
@@ -204,6 +204,7 @@ const matchesWithLookback = ({
       llmOutput: match.llmOutput,
       output,
       visibleText,
+      isVisible: visibleText.length > 0,
     };
 
     return [...acc, matchWithLookback];

--- a/packages/react/src/core/useLLMOutput/helper.ts
+++ b/packages/react/src/core/useLLMOutput/helper.ts
@@ -178,11 +178,11 @@ const matchesWithLookback = ({
     const visibleTextSoFar = acc
       .map((m) => m.visibleText.length)
       .reduce((a, b) => a + b, 0);
-    const localVisibleTextLengthTarget =
-      visibleTextLengthTarget - visibleTextSoFar;
-    if (localVisibleTextLengthTarget <= 0) {
-      return acc;
-    }
+    const localVisibleTextLengthTarget = Math.max(
+      visibleTextLengthTarget - visibleTextSoFar,
+      0,
+    );
+
     const isLastMatch = index === matches.length - 1;
     const isComplete = !isLastMatch || isStreamFinished;
     const { output, visibleText } = match.block.lookBack({

--- a/packages/react/src/core/useLLMOutput/index.test.tsx
+++ b/packages/react/src/core/useLLMOutput/index.test.tsx
@@ -59,6 +59,7 @@ describe("useLLMOutput Hook", () => {
           "hello isComplete:false visibleTextLengthTarget:100 isStreamFinished:false",
         outputRaw: "hello",
         visibleText: "hello",
+        isVisible: true,
         priority: 0,
         llmOutput: "hello",
         isComplete: false,

--- a/packages/react/src/core/useLLMOutput/types.ts
+++ b/packages/react/src/core/useLLMOutput/types.ts
@@ -20,6 +20,7 @@ export type BlockMatchNoLookback = MatchBase & {
 export type LLMOutputMatchWithLookBack = LLMOutputMatch & {
   output: string;
   visibleText: string;
+  isVisible: boolean;
 };
 
 export type MaybeLLMOutputMatch = LLMOutputMatch | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,8 +822,8 @@ importers:
         specifier: ^0.7.0
         version: link:../../../packages/react
       ai:
-        specifier: ^3.1.13
-        version: 3.1.13(react@18.2.0)(solid-js@1.8.17)(svelte@4.2.17)(vue@3.4.27)(zod@3.23.8)
+        specifier: ^3.1.14
+        version: 3.1.14(react@18.2.0)(solid-js@1.8.17)(svelte@4.2.17)(vue@3.4.27)(zod@3.23.8)
       html-react-parser:
         specifier: ^5.1.10
         version: 5.1.10(@types/react@18.2.73)(react@18.2.0)
@@ -5154,8 +5154,8 @@ packages:
       zod-to-json-schema: 3.22.5(zod@3.22.4)
     dev: false
 
-  /ai@3.1.13(react@18.2.0)(solid-js@1.8.17)(svelte@4.2.17)(vue@3.4.27)(zod@3.23.8):
-    resolution: {integrity: sha512-1DVdKv2MgkBe7OLa+S4uKFVXNZPWFFaW0rjcNi1bH8nH8b3vqurby0McWUUY77r/RA1i/QY4LnWobn/dPO0Qcg==}
+  /ai@3.1.14(react@18.2.0)(solid-js@1.8.17)(svelte@4.2.17)(vue@3.4.27)(zod@3.23.8):
+    resolution: {integrity: sha512-yW9ipraLm2PzzWc74eWUUVUIVZbO/Ggv//83iBfDkOTndrBmFqyIk6DtVVzf+RwKNUYuZzj8v5MKcgnHQhceXw==}
     engines: {node: '>=18'}
     peerDependencies:
       openai: ^4.42.0

--- a/tooling/examples/src/custom/customExample.ts.hbs
+++ b/tooling/examples/src/custom/customExample.ts.hbs
@@ -39,7 +39,7 @@ const MarkdownComponent: LLMOutputComponent = ({ blockMatch }) => {
 
 // Customize this component with your own styling
 const ButtonsComponent: LLMOutputComponent = ({ blockMatch }) => {
-  const isVisible = blockMatch.visibleText.length > 0;
+  const isVisible = blockMatch.isVisible;
   if (!isVisible) {
     return null;
   }

--- a/tooling/examples/src/generateExamples.ts
+++ b/tooling/examples/src/generateExamples.ts
@@ -12,7 +12,7 @@ const commonParams: CommonParams = {
   examplesFolder: path.join(repoRoot, "examples"),
   nextjsVersion: "14.2.3",
   viteVersion: "5.2.3",
-  llmUiVersion: "0.6.0",
+  llmUiVersion: "0.7.0",
 };
 
 (async () => {


### PR DESCRIPTION
@llm-ui/markdown
Markdown visible text no longer includes \n. This was causing behavior that was difficult to predict.

@llm-ui/react
- `useLLMOutput` hook now returns all known blocks, it doesn't truncate the blocks based on how much is visible.
- `isVisible: true|false` added to 'blockMatch' returned from `useLLMOutput` hook.

@llm-ui/custom

- New options:
  - defaultVisible: false,
  - visibleKeyPaths: [],
  - invisibleKeyPaths: [],
