### PR TITLE
Performance fixes. Memoize block calculation

### DIFF
--- a/.changeset/three-adults-explain.md
+++ b/.changeset/three-adults-explain.md
@@ -1,0 +1,5 @@
+---
+"@llm-ui/react": patch
+---
+
+Performance improvements: use `React.memo` to avoid recalculating blocks

--- a/packages/react/src/core/useLLMOutput/index.tsx
+++ b/packages/react/src/core/useLLMOutput/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { throttleBasic } from "../../throttle";
 import { matchBlocks } from "./helper";
 import {
@@ -59,17 +59,21 @@ export const useLLMOutput = ({
   const visibleTextIncrementsRef = useRef<number[]>([]);
   const visibleTextLengthTargetRef = useRef<number>(0);
 
+  const memoMatchBlocks = useMemo(() => {
+    return matchBlocks({
+      llmOutput,
+      blocks,
+      fallbackBlock,
+      isStreamFinished,
+    });
+  }, [llmOutput, isStreamFinished]);
+
   const [{ blockMatches, ...state }, setState] = useState<
     Omit<UseLLMOutputReturn, "restart">
   >({
     ...initialState,
     finishCount: 0,
-    blockMatches: matchBlocks({
-      llmOutput,
-      blocks,
-      fallbackBlock,
-      isStreamFinished,
-    }),
+    blockMatches: memoMatchBlocks,
   });
 
   const reset = useCallback(() => {


### PR DESCRIPTION
Performance improvements: use `React.memo` to avoid recalculating blocks
