### PR TITLE
Add React 19 peer dep support

### DIFF
--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -43,7 +43,7 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
+    "react": ">=18.0.0 <20.0.0",
     "shiki": "^1.6.0"
   }
 }

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -43,6 +43,6 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": ">=18.0.0 <20.0.0"
   }
 }

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -47,7 +47,7 @@
     "typescript": "^5.4.3"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
+    "react": ">=18.0.0 <20.0.0",
     "zod": "^3.23.8"
   }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -32,7 +32,7 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": ">=18.0.0 <20.0.0"
   },
   "dependencies": {
     "@llm-ui/react": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": ">=18.0.0 <20.0.0"
   },
   "devDependencies": {
     "@llm-ui/tsconfig": "workspace:*",


### PR DESCRIPTION
### Why
If a consumer is on React 19, then they get an error about the React 18 peer dependency constraint. 

### What
This PR enables React 19 peer dep support for all llm-ui subpackages. 

### Testing
This seems to have no issues from my testing with React 19 compatibility.

Closes https://github.com/richardgill/llm-ui/issues/288

